### PR TITLE
Fix accidental unsoundness with mutable mutable references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+
+[[package]]
 name = "serde"
 version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +564,7 @@ name = "yakui-macroquad"
 version = "0.3.0"
 dependencies = [
  "macroquad",
+ "send_wrapper",
  "yakui",
  "yakui-miniquad",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["gui"]
 [dependencies]
 macroquad = { version = "0.4.5", default-features = false }
 yakui-miniquad = "0.3.0"
+send_wrapper = "0.6.0"
 
 [dev-dependencies]
 yakui = "0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 //! }
 //!```
 
+use send_wrapper::SendWrapper;
 use std::sync::{RwLock, RwLockWriteGuard};
 
 use macroquad::miniquad as mq;
@@ -52,23 +53,21 @@ pub use macroquad;
 struct Yakui(YakuiMiniQuad, usize);
 
 // Global variable and global functions because it's more like macroquad way
-static mut YAKUI: RwLock<Option<Yakui>> = RwLock::new(None);
+static YAKUI: RwLock<Option<SendWrapper<Yakui>>> = RwLock::new(None);
 
-fn get_yakui() -> RwLockWriteGuard<'static, Option<Yakui>> {
-    unsafe {
-        match YAKUI.try_write() {
-            Ok(mut yakui) => {
-                if yakui.is_some() {
-                    yakui
-                } else {
-                    *yakui = Some(Yakui::new());
-                    yakui
-                }
+fn get_yakui() -> RwLockWriteGuard<'static, Option<SendWrapper<Yakui>>> {
+    match YAKUI.try_write() {
+        Ok(mut yakui) => {
+            if yakui.is_some() {
+                yakui
+            } else {
+                *yakui = Some(SendWrapper::new(Yakui::new()));
+                yakui
             }
-            Err(_) => panic!(
-                "tried to borrow yakui mutably twice, did you accidentally nest ui or cfg calls?"
-            ),
         }
+        Err(_) => panic!(
+            "tried to borrow yakui mutably twice, did you accidentally nest ui or cfg calls?"
+        ),
     }
 }
 


### PR DESCRIPTION
# Changes
* Fixes unsoundness issue where you could end up with multiple mutable references to the yakui context by replacing direct access to a static mut reference with a RwLock instead, along with wrapping the yakui context in SendWrapper so that it can only be accessed from the thread it is first created on (which feels like it should be the intent anyways)